### PR TITLE
Update wmstlayer.py

### DIFF
--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -65,7 +65,15 @@ class WMSTRasterLayer(TimeRasterLayer):
         timeString = "TIME={}/{}".format(
             time_util.datetime_to_str(startTime, self.timeFormat),
             time_util.datetime_to_str(endTime, self.timeFormat))
-        dataUrl = self.IGNORE_PREFIX + self.originalUri + self.addUrlMark() + timeString
+
+        uriPos = self.originalUri.find("url=")
+        uriEnd = self.originalUri[uriPos:].find("&")
+        uriEnd = uriPos + uriEnd if uriEnd != -1 else len(self.originalUri)
+        replaceUri = self.originalUri[uriPos:uriEnd]
+        newUri = replaceUri + self.addUrlMark(replaceUri) + timeString
+        replacedOriginalUri = self.originalUri.replace(replaceUri, newUri)
+
+        dataUrl = self.IGNORE_PREFIX + replacedOriginalUri
         #print "original URL: " + self.originalUri
         #print "final URL: " + dataUrl
         self.layer.dataProvider().setDataSourceUri(dataUrl)


### PR DESCRIPTION
When you use a WMS service that requires authentication, QGIS adds to the originalUri as last parameter "username=john" after the "uri=" parameter.
As an example, it can look like this: ```...&uri=https://wms.example.org/wms&username=john```
Now the current timeString addition to that url results in ```...&uri=https://wms.example.org/wms&username=john?TIME=<time1>/<time2>``` which then is discarded by QGIS as it is not a valid url.
Instead, we want to have the following result in this case: ```...&uri=https://wms.example.org/wms?TIME=<time1>/<time2>&username=john``` which works. When having additional parameters in the uri, like ```...&uri=https://wms.example.org/wms?version=1.1.0&username=john```, then we obviously need to add via %26, as in ```...&uri=https://wms.example.org/wms?version=1.1.0%26TIME=<time1>/<time2>&username=john```

This fix allows all these use cases and also still works with uris that don't need authentication (means they end with ```...&uri=https://wms.example.org/wms?version=1.1.0``` or ```...&uri=https://wms.example.org/wms``` without username attribute.